### PR TITLE
Prevent adding redundant service worker support if present in AMP plugin

### DIFF
--- a/Classes/class-amp.php
+++ b/Classes/class-amp.php
@@ -10,16 +10,20 @@ class AMP {
 		 */
 
 		add_filter( pwp_get_instance()->Manifest->filter, [ $this, 'amp_start_url' ] );
-		add_action( 'amp_post_template_head', [ pwp_get_instance()->Manifest, 'manifest_link_and_meta' ] );
 
-		/**
-		 * Register SW
-		 */
+		// Skip integrating with AMP plugin's Reader mode templates if on a recent version that directly supports integration with the PWA plugin.
+		if ( class_exists( 'AMP_Service_Worker' ) ) {
+			add_action( 'amp_post_template_head', [ pwp_get_instance()->Manifest, 'manifest_link_and_meta' ] );
 
-		add_filter( 'amp_post_template_head', [ $this, 'amp_enqueue_sw_module' ] );
-		add_action( 'amp_post_template_footer', [ $this, 'amp_register_sw' ] );
-		add_action( 'parse_request', [ $this, 'wp_swamp_register' ] );
-		add_filter( 'query_vars', [ $this, 'wp_add_swamp_query_var' ] );
+			/**
+			 * Register SW
+			 */
+
+			add_filter( 'amp_post_template_head', [ $this, 'amp_enqueue_sw_module' ] );
+			add_action( 'amp_post_template_footer', [ $this, 'amp_register_sw' ] );
+			add_action( 'parse_request', [ $this, 'wp_swamp_register' ] );
+			add_filter( 'query_vars', [ $this, 'wp_add_swamp_query_var' ] );
+		}
 	}
 
 	public function amp_start_url( $values ) {


### PR DESCRIPTION
The AMP plugin added direct support for the PWA plugin and installation of the service worker using `amp-install-serviceworker` in https://github.com/ampproject/amp-wp/pull/1261.

So this PR prevents adding those hooks if it detects the supported AMP plugin version is running.

Disclaimer: I did not test this code, and it's possible that the AMP plugin may not have been loaded when the code runs, and so the `AMP_Service_Worker` class may not exist yet.